### PR TITLE
Cleanup Background.jsx

### DIFF
--- a/src/components/widgets/Background.jsx
+++ b/src/components/widgets/Background.jsx
@@ -3,7 +3,7 @@ import supportsWebP from 'supports-webp';
 import * as Constants from '../../modules/constants';
 
 export default class Background extends React.PureComponent {
-  setBackground(url, colour) { // Sets the attributes of the background image
+  setBackground(url, colour, credit) { // Sets the attributes of the background image
     const background = colour ? `background-color: ${colour};` : `background-image: url(${url});`
 
     document.querySelector('#backgroundImage').setAttribute(
@@ -12,6 +12,8 @@ export default class Background extends React.PureComponent {
       -webkit-filter: blur(${localStorage.getItem('blur')}px);
       -webkit-filter: brightness(${localStorage.getItem('brightness')}%);`
     );
+    
+    if (credit === 'false') document.querySelector('#credits').style.display = 'none'; // Hide the credit
   }
 
   setCredit(photographer) {
@@ -44,11 +46,9 @@ export default class Background extends React.PureComponent {
       const randomPhoto = photoPack[Math.floor(Math.random() * photoPack.length)];
       this.setBackground(randomPhoto.url.default);
     } else if (customBackgroundColour) {
-      document.querySelector('#credits').style.display = 'none'; // Hide the credit
-      this.setBackground(null, customBackgroundColour);
+      this.setBackground(null, customBackgroundColour, 'false');
     } else if (customBackground !== '') { // Local
-      document.querySelector('#credits').style.display = 'none'; // Hide the credit
-      this.setBackground(customBackground);
+      this.setBackground(customBackground, null, 'false');
     } else { // Online
       try { // First we try and get an image from the API...
         const enabled = localStorage.getItem('webp');
@@ -56,14 +56,11 @@ export default class Background extends React.PureComponent {
 
         switch (localStorage.getItem('backgroundAPI')) {
           case 'unsplash':
-            requestURL = 'https://unsplash.muetab.xyz/getImage';
+            requestURL = `${Constants.UNSPLASH_URL}/getImage`;
             break;
           default: // Defaults to Mue
-            if (await supportsWebP && enabled === 'true') {
-              requestURL = `${Constants.API_URL}/getImage?webp=true`;
-            } else {
-              requestURL = `${Constants.API_URL}/getImage?category=Outdoors`;
-            }
+            if (await supportsWebP && enabled === 'true') requestURL = `${Constants.API_URL}/getImage?webp=true`;
+            else requestURL = `${Constants.API_URL}/getImage?category=Outdoors`;
             break;
         }
 

--- a/src/components/widgets/Background.jsx
+++ b/src/components/widgets/Background.jsx
@@ -4,7 +4,7 @@ import * as Constants from '../../modules/constants';
 
 export default class Background extends React.PureComponent {
   setBackground(url, colour) { // Sets the attributes of the background image
-    let background = colour ? `background-color: ${colour};` : `background-image: url(${url});`
+    const background = colour ? `background-color: ${colour};` : `background-image: url(${url});`
 
     document.querySelector('#backgroundImage').setAttribute(
       'style',
@@ -67,7 +67,7 @@ export default class Background extends React.PureComponent {
             break;
         }
 
-        let data = await (await fetch(requestURL)).json(); // Fetch JSON data from requestURL
+        const data = await (await fetch(requestURL)).json(); // Fetch JSON data from requestURL
 
         if (data.statusCode === 429) {
           this.doOffline(); // If we hit the rate limit, fallback to local images


### PR DESCRIPTION
Cleans up Background.jsx a bit.

I think this file could be made smaller but it would require some changes in how the mode is determined, instead of relying on localStorage to store state throughout the application, or at least having a singular "mode" key in localStorage whose value would return the current mode, e.g. "offline", "photoPack", "customBackground", a one-to-many mapping instead of the current many one-to-ones.

I'm not entirely sure, but this is what I've got so far.