### PR TITLE
Fixing console warning: index.js:1406 Each child in a list should have a unique "key" prop.

### DIFF
--- a/src/components/modals/settings/sections/SearchSettings.jsx
+++ b/src/components/modals/settings/sections/SearchSettings.jsx
@@ -29,7 +29,7 @@ export default class SearchSettings extends React.PureComponent {
             <label htmlFor='searchEngine'>{this.props.language.searchbar.searchengine} </label>
               <select className='select-css' name='searchEngine' id='searchEngine' onChange={() => SettingsFunctions.setSearchEngine(document.getElementById('searchEngine').value)}>
                 {searchEngines.map((engine) =>
-                  <option className='choices' value={engine.settingsName}>{engine.name}</option>
+                  <option key={engine.name} className='choices' value={engine.settingsName}>{engine.name}</option>
                 )}
                 <option className='choices' value='custom'>Custom</option>
               </select>


### PR DESCRIPTION
Each child in a list should have a unique "key" prop.
See https://fb.me/react-warning-keys for more information.

This warning would appear every time a user clicked on the Settings cog.