### PR TITLE
These bugs fix warnings/errors I saw in the console log.

### DIFF
--- a/src/components/modals/MainModal.jsx
+++ b/src/components/modals/MainModal.jsx
@@ -8,7 +8,7 @@ export default class MainModal extends React.PureComponent {
     constructor(...args) {
         super(...args);
         this.state = {
-            tab: <Settings language={this.props.language.settings} toastLanguage={this.props.toastLanguage} />,
+            tab: <Settings language={this.props.language.settings} toastLanguage={this.props.language.toasts} />,
             settingsActive: 'active',
             addonsActive: '',
             marketplaceActive: ''

--- a/src/components/widgets/Background.jsx
+++ b/src/components/widgets/Background.jsx
@@ -34,7 +34,7 @@ export default class Background extends React.PureComponent {
       `${background}; -webkit-filter: blur(${localStorage.getItem('blur')}px) brightness(${brightness}%);`
     );
 
-    if (credit === 'false') document.querySelector('#credits').style.display = 'none'; // Hide the credit
+    if (credit === 'false' && document.querySelector('#credits')) document.querySelector('#credits').style.display = 'none'; // Hide the credit
   }
 
   setCredit(photographer, unsplash, url) {

--- a/src/components/widgets/Notes.jsx
+++ b/src/components/widgets/Notes.jsx
@@ -8,11 +8,11 @@ export default class Notes extends React.PureComponent {
     constructor(...args) {
         super(...args);
         this.state = {
-            notes: localStorage.getItem('notes')
+            notes: localStorage.getItem('notes') || ""
         };
     }
 
-    setNotes(e) {
+    setNotes = (e) => {
         localStorage.setItem('notes', e.target.value);
         this.setState({ notes: e.target.value });
     };


### PR DESCRIPTION
* Fixed broken reference to toast language
  Clicking on Reset in Settings will no longer crash the app

* Fixed null reference for a hidden credits section.
  The DOM selector always assumed the Credits section was shown.

* Fixed case when "notes" is not defined in local storage.
  First time launch when there are no local storage items caused this bug.

* Corrected scope of "this" on Notes.jsx
  Typing a note crashed the app. This was because `this` was scoped incorrectly.