### PR TITLE
Adding github action for automated submission and dependabot upkeep

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+name: automerge
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+  automerge:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,27 @@
+name: Submit
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to submit, i.e 6.0.4"
+        required: true
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: latest
+      - name: Download Github Release Assets
+        uses: plasmo-corp/download-release-asset@v1.0.0
+        with:
+          tag: ${{ github.event.inputs.tag }}
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /opt/hostedtoolcache/chromium/latest/x64/chrome
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ yarn-error.log
 stats.json
 yarn.lock
 *.zip
+
+keys.json


### PR DESCRIPTION
Hi friends!

Love mue, I have been enjoying it a lot lately :D I was looking for ways to contribute, and found that since your codebase doesn't have continuous integration, adding that might be helpful. 

I created a 2 workflows in this PR:

- `automerge`: automate the dependabot merging to reduce PR noise, using https://github.com/fastify/github-action-merge-dependabot
- `submit`: automate the zip submission process to the Chrome/Firefox/Edge/Opera stores automatically, using [bpp](https://browser.market) and [download-release-asset](https://github.com/plasmo-corp/download-release-asset). It is set to run manually from the github action tab, with a tag input to specify the version to submit. We can tweak that to be as granular as needed! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

The `SUBMIT_KEYS` secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample key for you:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "Chrome.zip",
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "Firefox.zip",
    "extId": "123",
    "apiKey": "abcd",
    "apiSecret": "abcd"
  },
  "edge": {
    "zip": "Chrome.zip",
    "extId": "123",
    "cookie": "abcd"
  },
  "opera": {
    "zip": "Chrome.zip",
    "csrftoken": "abcd",
    "sessionid": "abcd",
    "packageId": 0
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)