### PR TITLE
Fix quick links behavior in small windows

### DIFF
--- a/src/features/quicklinks/quicklinks.scss
+++ b/src/features/quicklinks/quicklinks.scss
@@ -21,6 +21,8 @@
   z-index: 1;
   display: flex;
   place-content: center center;
+  flex-wrap: wrap;
+  padding: 0 25px;
   gap: 12px;
 
   textarea {


### PR DESCRIPTION
I fixed the quick links behavior in small windows, see the comparison.

**Before:**
![image](https://github.com/user-attachments/assets/613f1068-15a7-4f98-9b49-6be27d13a27f)

**After:**
![image](https://github.com/user-attachments/assets/c402f1d3-3703-47a2-9a61-d2b1c23b9b95)


Now the page looks good even when resizing the page.

I didn't fix the linting and formatting errors as they were already present. 