### PR TITLE
fix(i18n): restore en_US greeting.events as string

### DIFF
--- a/src/i18n/locales/en_US.json
+++ b/src/i18n/locales/en_US.json
@@ -183,15 +183,7 @@
           },
           "greeting": {
             "title": "Greeting",
-            "events": {
-              "0": "E",
-              "1": "v",
-              "2": "e",
-              "3": "n",
-              "4": "t",
-              "5": "s",
-              "title": "Events"
-            },
+            "events": "Events",
             "events_description": "Control events on Mue such as birthdays.",
             "enable_events": "Show messages on special days",
             "default": "Default greeting message",


### PR DESCRIPTION
## Summary

Restores `greeting.events` in `src/i18n/locales/en_US.json` from a character-indexed object back to a plain string.

> **Scope note:** This PR only addresses the locale bug from issue #1178. The two related issues mentioned there — the News widget React crash when `api.muetab.com/v2/news` returns 404, and the missing `.trim()` on quicklink URLs before favicon fetch — are **not** touched here. Leaving the issue open after this merges so those can be tracked separately (or split into their own issues, whichever the maintainers prefer).

## What was wrong

```json
"events": {
  "0": "E", "1": "v", "2": "e", "3": "n", "4": "t", "5": "s",
  "title": "Events"
}
```

Looks like someone spread the string `"Events"` across numeric keys, then nested an extra `title` inside. Every other locale in the repo ships this key as a plain string (e.g. `ar.json`, `az.json`, `en_GB.json`).

## Effect of the bug

Opening Settings → Greeting with `en_US` selected throws:

```
Error: "modals.main.settings.sections.greeting.events" in the "en_US" locale is not an array or string
```

The translate helper expects string or array, so the whole Greeting panel unmounts and renders the generic "Failed to load this component of Mue" error fallback.

## Fix

```diff
-            "events": {
-              "0": "E",
-              "1": "v",
-              "2": "e",
-              "3": "n",
-              "4": "t",
-              "5": "s",
-              "title": "Events"
-            },
+            "events": "Events",
```

One line, no other locale touched.

## Verification

- `python -m json.tool src/i18n/locales/en_US.json` passes (JSON still valid).
- Diff matches the shape used by `en_GB.json` and the other locales for the same key.

Refs #1178